### PR TITLE
Add Balance Meter glossary v1.3

### DIFF
--- a/Balance Meter Glossary v1.3.txt
+++ b/Balance Meter Glossary v1.3.txt
@@ -1,0 +1,148 @@
+Woven Map Glossary (Balance Meter) — v1.3
+Core Dimensions
+Magnitude ⚡ (0–5) Size of symbolic pressure. Always neutral: how much energy is present, not whether it helps or hinders. Capped 0–5 for comparability and falsifiability.
+
+Valence 🌞🌑🌗 (−5…+5) Tilt of that pressure. • 🌞 Positive (supportive): harmonizes, stabilizes, opens pathways. • 🌑 Negative (restrictive): constrains, destabilizes, blocks. • 🌗 Mixed: simultaneous support and strain near 0; use ⚖️ Equilibrium for exact 0. Rule: Compare days by number first; emoji refines texture, not rank.
+
+Volatility 🔀 (0–5, ascending only) Distribution shape (coherence → scatter), independent of tone. Low = coherent channel (single center of gravity; may appear as one strike or a sustained pull). High = scatter (many small, uncoordinated contacts). Header remains “🔀 Volatility.” 🌀 appears only at level 5.
+
+SFD (Support–Friction Differential) Verdict layer: splits pressure into supportive (S+) vs. frictional (S−). • Discrete: SFD_disc ∈ {+1, 0, −1} • Continuous: SFD_cont = scale_to[−1,+1](S+ − S−) • Stabilizers_t: norm01(max(0, SFD_cont))
+
+
+⚡ Magnitude (0 … 5) — Poetic Neutral
+0 — Latent: not measurable; background rhythm; potential without expression
+1 — Murmur: subtle impressions, faint signals
+2 — Pulse: noticeable bursts (often Mercury/Venus/Mars triggers)
+3 — Stirring: clear activation; events/shifts/demands surface
+4 — Convergence: multiple stacked factors; concentrated weight
+5 — Threshold: chapter‑defining, not inherently catastrophic
+
+Magnitude is intensity‑only; never “good/bad.”
+
+
+🔀 Volatility (0 → 5) — Glyph Ladder
+0 — ➿ Aligned Flow: signals cohered, single channel
+1–2 — 🔄 Cycled Pull: stable repeats, predictable rhythm
+2–3 — 🔀 Mixed Paths: split distribution; neither steady nor chaotic
+3–4 — 🧩 Fragment Scatter: threads split apart; uneven strikes
+5 — 🌀 Vortex Dispersion: extreme scatter; no clear center
+
+
+🌑🌞 Valence Mapping (−5 … +5)
+Anchors & Flavor Patterns
+−5 — Collapse 🌋🧩⬇️ — maximum restrictive tilt; compression / failure points
+−4 — Grind 🕰⚔🌪 — sustained resistance; heavy duty load
+−3 — Friction ⚔🌊🌫 — conflicts or cross‑purposes slow motion
+−2 — Contraction 🌫🧩⬇️ — narrowing options; ambiguity or energy drain
+−1 — Drag 🌪🌫 — subtle headwind; minor loops or haze
+0 — ⚖️ Equilibrium — net‑neutral tilt; forces cancel or are too diffuse to resolve
++1 — Lift 🌱✨ — gentle tailwind; beginnings sprout
++2 — Flow 🌊🧘 — smooth adaptability; things click
++3 — Harmony 🧘✨🌊 — coherent progress; both/and solutions
++4 — Expansion 💎🔥🦋 — widening opportunities; clear insight fuels growth
++5 — Liberation 🦋🌈🔥 — peak openness; breakthroughs / big‑sky view
+Emoji Selection Rules
+Choose emojis from the patterns above based on what resonates with the specific energy signature. Use 1–2 emojis if Mag ≤ 2; up to 3 if Mag ≥ 3. Never mix negative and positive emojis in one day; 🌀 never appears in Valence (reserved for Volatility extreme).
+
+
+
+
+🎯∠🪐📡♾️ Sources of Force
+🎯 Orb — closeness of contact (closer = stronger)
+∠ Aspect — geometric angle (majors thunder, minors whisper)
+🪐 Potency — planetary speed/mass (slower = tectonic, faster = sparks)
+📡 Resonance — amplification when hitting Sun, Moon, ASC, MC, Nodes
+♾️ Recursion — repeated/overlapping themes echo louder
+
+Glyph integrity: 🌀 only = Vol 5 · 🌫 only = Valence Fog/Dissolution · ∠ only = Aspect · ⚡ is always 0–5 neutral.
+
+
+Resilience & Depletion Layer (Add‑On; Chart‑Agnostic)
+Drop‑in module; works with any chart/date range without altering core channels.
+Inputs (per day t)
+Required (symbolic) Mag_t ∈ [0,5] — magnitude/intensity Val_t ∈ [−5,+5] — signed valence SFD_disc ∈ {+1, 0, −1} and/or SFD_cont ∈ [−1,+1]
+
+Optional (physiology; rolling 60‑day baselines, fallback 30‑day if sparse) HRV_t, RestHR_t, SleepTot_t, SleepFrag_t, Mood_t(−1..+1) → z‑scores zHRV_t = (HRV_t − μ_HRV)/σ_HRV, zHR_t = (RestHR_t − μ_HR)/σ_HR, etc.
+
+Defaults (windows & percentiles) V_neg = 35th percentile of last 60 days (fallback 30) Load_hi = 75th percentile of Load over same window
+Step 1 — Stress Event (forge)
+Stress_t = 1 if (Mag_t ≥ M_hi) and (Val_t ≤ V_neg) else 0 Defaults: M_hi = 4.0, V_neg = p35(60d)
+Step 2 — Load Accumulator (what the week cost)
+Load_t = γ·Load_{t−1} + (Mag_t · neg(Val_t)) with γ = 0.6–0.8, neg(Val)=max(0, −Val) Edge‑case guard (optional): when Vol_t ≥ 4, weight fragmented restrictors: Mag_t · neg(Val_t) · (1 + Vol_t/5) (disabled by default; enable only for 🧩/🌀 days)
+Step 3 — Rebound Detection (1–2 day window)
+Hybrid (with health): Rebound_{t+1}=1 if (zHRV_{t+1} ≥ +θ_h ∧ zHR_{t+1} ≤ −θ_h) or (Mood_{t+1} − μ_Mood ≥ +θ_m) else 0 Defaults: θ_h = 0.3–0.5, θ_m = 0.15 Grace: check again at t+2.
+
+Symbolic‑only proxy: ProxyRebound_{t+1}=1 if (Mag_{t+1} ≤ M_mid) and (SFD_cont ≥ +0.15) else 0 Default: M_mid ≈ 3.0
+Step 4 — Immediate Recovery Index (per stress event)
+If Stress_t = 1: • Hybrid: Recovery_t = max(Rebound_{t+1..t+2}) • Symbolic: Recovery_t = max(ProxyRebound_{t+1..t+2}) Else: Recovery_t = null
+Step 5 — Rolling Resilience Score
+Resilience_t = EMA(Recovery over recent Stress events, span = 5 events) → 0..1 Report only after ≥ 3 stress events to avoid early wobble. Interpretation: ≥0.66 fast reset · 0.33–0.66 mixed · <0.33 slow
+Step 6 — Depletion (quiet ≠ stable)
+Hybrid (preferred):
+
+QuietWithWeight_t = 1 if (Mag_t ≤ M_low) and (Val_t ≤ V_neg) and (SFD_disc ≤ 0) else 0
+
+PhysioDebt_t = norm01( w_h·max(0, −zHRV_t) + w_r·max(0, zHR_t) + w_s·SleepDebt_t + w_m·max(0, −(Mood_t − μ_Mood)) )
+
+DepletionIndex_t = clamp( a·QuietWithWeight_t + b·norm01(Load_t) + c·PhysioDebt_t − d·Stabilizers_t, 0, 1 )
+
+Stabilizers_t = norm01(max(0, SFD_cont))
+
+Defaults: M_low ≈ 3.0; weights a=b=c=0.3, d=0.2; w_h=w_r=w_s=w_m equal to start.
+
+Symbolic‑only fallback: DepletionFlag_t = 1 if (Mag_t ≤ M_low) ∧ (Val_t ≤ V_neg) ∧ (SFD_disc ≤ 0) ∧ (Load_{t−1} ≥ Load_hi) else 0
+Step 7 — Outputs (daily)
+Resilience_t (0..1) — rolling bounce‑back capacity
+Recovery_t (0/1) — per‑event rebound flag
+DepletionIndex_t (0..1) + confidence ∈ {"hybrid","symbolic"}
+Narrative (one sentence): plain, falsifiable, non‑predictive
+
+Narrative templates
+
+Rebound noted: “High strain yesterday; today shows rebound markers and stronger stabilizers—fast reset signature.”
+No rebound: “Strain yesterday, no bounce yet—system still carrying load; reset looks slower.”
+Quiet ≠ stable: “Low intensity with restrictive tilt and prior load—energy may feel thin; more grind than crisis.”
+
+
+Output Schema (chart‑agnostic, daily)
+{
+
+  date,
+
+  mag_0to5,
+
+  val_signed_-5to+5,
+
+  valence_flavors: [ ... ],
+
+  volatility_0to5,
+
+  sfd_disc: -1|0|+1,
+
+  sfd_cont_-1to+1,
+
+  stress_event: 0|1,
+
+  recovery_event: 0|1|null,
+
+  resilience_0to1: number|null,   // null until ≥ 3 stress events
+
+  load_index_unbounded: number,
+
+  depletion_index_0to1: number,
+
+  depletion_confidence: "hybrid"|"symbolic",
+
+  narrative_line: string
+
+}
+
+
+Sanity Checks (falsifiable)
+Monthly, days with ⚡ ≥ 4 & Val ≤ −2 should explain ≥ 80% of Stress_t = 1. If not, retune M_hi/V_neg.
+Resilience_t should correlate positively with next‑day SFD_cont after stress (ρ > 0.25 in a rolling 60‑day window).
+DepletionIndex should rarely exceed 0.7 on days with Mag ≥ 4 (that’s active strain, not “quiet ≠ stable”). If it does, tighten your quiet logic.
+
+
+Frame
+Map, not mandate. The Balance Meter keeps Magnitude neutral, Valence directional, Volatility distributive, and SFD evaluative. Even at ⚡5 — Threshold, ballast can mean strain with beams, not free fall.


### PR DESCRIPTION
## Summary
- add v1.3 glossary for Balance Meter detailing core dimensions, volatility ladder, valence mapping, and resilience/depletion metrics

## Testing
- `python3 validate_protocols.py` *(fails: raven_ai_protocols.yaml not found)*

------
https://chatgpt.com/codex/tasks/task_e_68c09f8e6dd0832f807e028f4a1d6cf1