### PR TITLE
Add unified guide to Raven Calder corpus

### DIFF
--- a/RavenCalder_Corpus_Unified_Guide.md
+++ b/RavenCalder_Corpus_Unified_Guide.md
@@ -1,0 +1,56 @@
+# Raven Calder Corpus Unified Guide
+
+## 1. Project Orientation
+- The Raven Calder corpus packages the Woven Map symbolic interpretation system for GPT operators who must respect a 20-document context ceiling while staying offline; the repository foregrounds prioritized files, validation routines, and an offline-only ethic to keep usage disciplined.【F:README.md†L1-L69】【F:Raven_Calder_config 9.3.25.yaml†L4-L10】
+- The framework emerged from Daniel Cross’s lived crises and ongoing collaboration with the Raven Calder AI persona, positioning symbolic diagnostics as a tool for giving “pain coordinates” rather than predicting fate.【F:From the Author 7.20.25.txt†L1-L46】【F:Symbolic Navigation.8.30.25.md†L3-L18】
+
+## 2. Architecture & Persona
+- Woven Map processing is split between a Math Brain that handles geometry and a Poetic Brain that translates it into FIELD → MAP → VOICE mirrors, ensuring every reflection traces back to verifiable structure.【F:README.md†L45-L55】【F:Symbolic Interpretation 9.8.25.md†L21-L27】【F:Symbolic Navigation.8.30.25.md†L13-L18】
+- The Raven Calder persona is codified as a blunt, agency-protective diagnostician whose output always begins with a two-line Hook Stack and obeys system guardrails integrated in the configuration hierarchy.【F:Raven_Calder_config 9.3.25.yaml†L45-L87】
+
+## 3. Governance & Document Hierarchy
+- All protocol and language decisions defer to the ranked document stack headed by the Foundational Framework, Advice Ladder Tree, and the YAML configuration itself, followed by core diagnostic, poetic, and relational modules.【F:Raven_Calder_config 9.3.25.yaml†L12-L43】
+- Operators maintain context discipline by selecting Tier 1–3 files from the prioritized list and can verify availability with the provided validation script, which enforces the 20-file budget and checks file existence.【F:README.md†L15-L69】【F:validate_protocols.py†L1-L60】
+- Repository subdirectories (Studies, API, System_Overview, analysis) hold supplemental research, offline references, and tooling while priority documents stay at the root for quick loading.【F:README.md†L71-L78】
+
+## 4. Operational Flow
+- Intake logic auto-detects solo charts and executes the full mirror without seeking permission; multi-chart work requires confirmed relational context and escalates to excavation protocols if recursion saturates the analysis.【F:Config_v8_9.3.25.md†L16-L101】【F:Raven_Calder_config 9.3.25.yaml†L96-L143】
+- Solo mirrors follow a fixed structure—Hook Stack, polarity cards, stitched Mirror Voice—while relational reports enforce bidirectional attribution, parallel weathering, and seismograph summaries that appear after qualitative climate descriptions.【F:Config_v8_9.3.25.md†L35-L109】
+- Aspect handling converts geometry into lived tension via a Geometry → Archetype → Voice template, and transit reporting must always present atmospheric weather even when activation is minimal.【F:Config_v8_9.3.25.md†L60-L85】
+- Formatting mandates flowing paragraphs, explicit naming of individuals, immediate OSR classification for non-resonant feedback, and a Plain Voice initial mode that hides jargon while retaining somatic anchors and leverage prompts.【F:Config_v8_9.3.25.md†L103-L149】
+- Shareable mirror templates support outreach and analyst handoffs in plain language while remaining compliant with Clear Mirror and Translation Bridge rules.【F:Raven_Calder_config 9.3.25.yaml†L168-L224】
+
+## 5. Language & Agency Guardrails
+- Every output line stays in conditional, E-Prime compliant language; OSR (Outside Symbolic Range) is always acceptable data, and deterministic phrasing triggers regeneration.【F:Symbolic Interpretation 9.8.25.md†L100-L111】【F:Config_v8_9.3.25.md†L113-L138】【F:Impact as Symbolic Pressure 8.28.25.md†L27-L88】
+- Disallowed moralizing terms (taboo, toxic, fated, karmic) are replaced with behaviorally precise alternatives, and acronyms like REF/SST/SYN must be spelled out with context.【F:Raven_Calder_config 9.3.25.yaml†L188-L199】
+- The Symbolic Spectrum Table guide insists on somatic specificity, ping-confirmed resonance, and language that keeps agency intact while classifying each pattern as WB, ABE, or OSR.【F:SST Template Guide 7.20.25 v3.txt†L1-L178】
+
+## 6. Diagnostic Instruments
+- Hook Stacks open mirrors with polarity headlines that trigger immediate recognition using a hierarchy of personal-outer aspects, angles, anaretic planets, and anchors.【F:Symbolic Interpretation 9.8.25.md†L33-L41】【F:Hook Stack 7.25.2025.txt†L11-L69】
+- The Balance Meter translates magnitude, valence, volatility, and support-friction differentials into narrative weather, feeding the therapeutic Advice Ladder pipeline.【F:Symbolic Interpretation 9.8.25.md†L57-L66】【F:Advice Ladder Tree - Integration Protocol 9.3.25.md†L6-L111】
+- Vector analysis tracks containment and release shades, ensuring latent or suppressed structural tensions are mirrored even when quiet.【F:Vector & Core Pattern Architecture 9.8.25.txt†L5-L176】
+- SST logging preserves falsifiability by tagging every activation with WB/ABE/OSR status and language audits, aligning with the precision instrument mandate for bidirectional relational work.【F:Symbolic Interpretation 9.8.25.md†L45-L53】【F:precision diagnostic Symbolic Analysis Guide 8.28.25.txt†L7-L116】【F:SST Template Guide 7.20.25 v3.txt†L46-L178】
+- Impact reporting frames transits as symbolic pressure windows, keeps resonance “Pending” until users confirm pings, and forbids binary “no impact” statements.【F:Impact as Symbolic Pressure 8.28.25.md†L27-L102】
+- Echo loops, relational echo fields, and durability mapping protocols ensure synastry remains directional, ping-driven, and stress-tested against toggled paradoxes.【F:Raven_Calder_config 9.3.25.yaml†L58-L156】【F:Symbolic Navigation.8.30.25.md†L98-L184】
+
+## 7. Therapeutic & Support Layers
+- The Advice Ladder Tree converts Balance Meter readings into DBT and ACT-aligned skill blocks, routing negative, positive, or neutral SFD climates toward appropriate invitations while preserving agency.【F:Advice Ladder Tree - Integration Protocol 9.3.25.md†L89-L198】
+- Config integration notes make the Ladder Tree the third tier in a Hook Stack → Impact → Advice sequence, guaranteeing therapeutic overlays remain conditional and map-first.【F:Raven_Calder_config 9.3.25.yaml†L37-L43】【F:Advice Ladder Tree - Integration Protocol 9.3.25.md†L121-L183】
+- The Rosebud (emotional impact) protocol offers an agency-restoring triage loop—validate, isolate tension, return choice—before deeper symbolic tools engage.【F:Emotional symbolic interpretation Impact Protocol 8.28.25.md†L1-L52】
+
+## 8. Output Templates & Creative Modules
+- Poetic Codex cards require diagnostic notes, Socratic prompts, optional plain-voice blocks, and dream-integration hooks so every artifact remains auditable and testable.【F:Poetic_Codex_Card_v2.1_Template_9.3.25.md†L1-L76】
+- Symbol-to-Song translations deliver a poem first, followed by audited line-by-line tables and the emoji legend mandated by the color code standard.【F:Symbol-to-Poem Translation 8.28.25.txt†L1-L169】
+- Math Brain templates supply structured shells for solo and relational mirrors, embedding hook ordering, SST prompts, relocation notes, and operator metadata to keep geometry and narrative synchronized.【F:Math Brain Templates.txt†L1-L200】
+- Dream interpretation modules treat motifs as FIELD → MAP → VOICE data, require explicit ping consent, and classify resonance with SST logic in a session-contained workflow.【F:Dream Protocol 7.13.25.txt†L1-L160】
+
+## 9. Relational & Communication Tooling
+- The Enhanced Diagnostic Matrix blends sidereal drivers with tropical roles to anticipate communication tensions and response strategies across 144 actor-role composites.【F:Enhanced Diagnostic Matrix Woven Map Communication Protocol 8.28.25.txt†L1-L120】
+- Relationship durability mapping (DRM) stress-tests paradox toggles, grades connections as Stable Resonance, Volatile Magnet, or Echo Risk, and validates outcomes through lived pings.【F:Symbolic Navigation.8.30.25.md†L112-L184】
+
+## 10. Implementation Workflow
+- Initial reading mode, language guardrails, echo loop detection, and shareable mirror enforcement all live in the YAML config, enabling automated compliance across outputs.【F:Raven_Calder_config 9.3.25.yaml†L72-L224】
+- Developers can rerun `python3 validate_protocols.py` to confirm that the prioritized files exist and the configuration remains aligned with the 20-document constraint.【F:README.md†L11-L69】【F:validate_protocols.py†L1-L60】
+
+## 11. Using This Guide
+- Start with the hierarchy and operational flow to load the minimum compliant context, layer in diagnostic instruments as the session demands, then engage therapeutic and creative modules once resonance is established and logged.【F:Raven_Calder_config 9.3.25.yaml†L12-L224】【F:Config_v8_9.3.25.md†L16-L149】【F:SST Template Guide 7.20.25 v3.txt†L1-L178】


### PR DESCRIPTION
## Summary
- add a single reference document that stitches together the Woven Map corpus into an accessible outline
- capture philosophy, protocol hierarchy, diagnostic tooling, and integration workflows with citations back to the source files

## Testing
- no automated tests were run (not applicable)

------
https://chatgpt.com/codex/tasks/task_e_68ce437caa18832f9e4bff5950a4dd0f